### PR TITLE
建议不要重载simditor的核心代码

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
   ],
 	"dependencies": {
 		"jquery": "~2.1.0",
-		"simditor": "~1.0.0"
+		"simditor": "master"
 	}
 }

--- a/lib/simditor-video.js
+++ b/lib/simditor-video.js
@@ -23,41 +23,12 @@
 
     VideoButton.prototype.disableTag = 'pre, table';
 
-    VideoButton.prototype.setupVideoConfig = function() {
-      this.editor.formatter._allowedTags.push('embed');
-      this.editor.formatter._allowedAttributes['embed'] = ['allowfullscreen', 'id', 'quality', 'width', 'height', 'align', 'src', 'type'];
-      return this.editor.sync = (function(_this) {
-        return function() {
-          var children, cloneBody, emptyP, firstP, lastP, val;
-          cloneBody = _this.editor.body.clone();
-          _this.editor.formatter.undecorate(cloneBody);
-          _this.editor.formatter.format(cloneBody);
-          _this.editor.formatter.autolink(cloneBody);
-          children = cloneBody.children();
-          lastP = children.last('p');
-          firstP = children.first('p');
-          while (lastP.is('p') && !lastP.text() && !lastP.find('img').length && !lastP.find('embed').length) {
-            emptyP = lastP;
-            lastP = lastP.prev('p');
-            emptyP.remove();
-          }
-          while (firstP.is('p') && !firstP.text() && !firstP.find('img').length && !firstP.find('embed').length) {
-            emptyP = firstP;
-            firstP = lastP.next('p');
-            emptyP.remove();
-          }
-          val = $.trim(cloneBody.html());
-          _this.editor.textarea.val(val);
-          return val;
-        };
-      })(this);
-    };
-
     VideoButton.prototype.render = function() {
       var args;
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+      this.editor.formatter._allowedTags.push('embed');
+      this.editor.formatter._allowedAttributes['embed'] = ['allowfullscreen', 'id', 'quality', 'width', 'height', 'align', 'src', 'type'];
       VideoButton.__super__.render.apply(this, args);
-      this.setupVideoConfig();
       return this.popover = new VideoPopover(this);
     };
 

--- a/src/simditor-video.coffee
+++ b/src/simditor-video.coffee
@@ -14,40 +14,12 @@ class VideoButton extends SimditorButton
 
   disableTag: 'pre, table'
 
-  setupVideoConfig: ->
+  render: (args...) ->
     @editor.formatter._allowedTags.push 'embed'
     @editor.formatter._allowedAttributes['embed'] = ['allowfullscreen', 'id', 'quality', 'width', 'height', 'align', 'src', 'type']
 
-    # overwrite sync to prevent removing embed element at the last/start content
-    @editor.sync = =>
-      cloneBody = @editor.body.clone()
-      @editor.formatter.undecorate cloneBody
-      @editor.formatter.format cloneBody
-
-      # generate `a` tag automatically
-      @editor.formatter.autolink cloneBody
-
-      # remove empty `p` tag at the start/end of content
-      children = cloneBody.children()
-      lastP = children.last 'p'
-      firstP = children.first 'p'
-      while lastP.is('p') and !lastP.text() and !lastP.find('img').length and !lastP.find('embed').length
-
-        emptyP = lastP
-        lastP = lastP.prev 'p'
-        emptyP.remove()
-      while firstP.is('p') and !firstP.text() and !firstP.find('img').length and !firstP.find('embed').length
-        emptyP = firstP
-        firstP = lastP.next 'p'
-        emptyP.remove()
-
-      val = $.trim(cloneBody.html())
-      @editor.textarea.val val
-      val
-
-  render: (args...) ->
     super args...
-    @setupVideoConfig()
+
     @popover = new VideoPopover(@)
 
   parseVideoSrc: (src) ->


### PR DESCRIPTION
我对simditor做了一个hotfix，现在sync的时候不会去掉首尾的视频标签了，你可以测试一下

另外，如果真的需要修改simditor的方法里增加代码建议通过绑定自定义事件来实现，如果simditor没有对应的事件（比如sync方法里就没有sync事件），你可以open一个issue请求我们加上事件

还有，我把bower.json里simdior的version改成了master，这样bower会自动安装master分支最新的commit，这样改是因为刚才的hotfix还没有发布版本，所以等1.0.3发布之后建议把version改成1.0.3
